### PR TITLE
202 for launch of /api/cold-start

### DIFF
--- a/src/pages/[[...parts]].tsx
+++ b/src/pages/[[...parts]].tsx
@@ -28,8 +28,7 @@ export default function Home ({
 
 	const { data: coldStartLoading } = useQuery(["cold-start"], {
 		queryFn: () => fetch("/api/cold-start", { headers: { Cache: "no-store" } })
-			.then((res) => res.json())
-			.then((json) => !json.done)
+			.then((res) => res.status === 202)
 			.catch(() => false),
 	})
 	socketClient.loading.useSubscription({

--- a/src/pages/api/cold-start.tsx
+++ b/src/pages/api/cold-start.tsx
@@ -21,7 +21,7 @@ export const loadingStatus = (globalThis.loadingStatus || {
 // @ts-expect-error -- see above
 globalThis.loadingStatus = loadingStatus
 
-function act() {
+function act () {
 	if (loadingStatus.promise) {
 		return
 	}
@@ -163,10 +163,10 @@ function act() {
 		})
 }
 
-export default async function cover(req: NextApiRequest, res: NextApiResponse) {
+export default async function cover (req: NextApiRequest, res: NextApiResponse) {
 	if (loadingStatus.populated) {
-		return res.status(200).json({ done: true })
+		return res.status(204).end()
 	}
 	act()
-	return res.status(202).json({ done: false })
+	return res.status(202).end()
 }

--- a/src/pages/api/cold-start.tsx
+++ b/src/pages/api/cold-start.tsx
@@ -168,5 +168,5 @@ export default async function cover(req: NextApiRequest, res: NextApiResponse) {
 		return res.status(200).json({ done: true })
 	}
 	act()
-	return res.status(200).json({ done: false })
+	return res.status(202).json({ done: false })
 }


### PR DESCRIPTION
just because it's more fun to have variety in http status codes (and minor argument: avoids encoding/decoding JSON `{done: false}`)