### PR TITLE
Virtualized `TrackList`

### DIFF
--- a/src/components/AlbumList/index.tsx
+++ b/src/components/AlbumList/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames"
-import { type ForwardedRef, startTransition, useEffect, useRef, useState, forwardRef, useDeferredValue } from "react"
+import { type ForwardedRef, startTransition, useRef, forwardRef, useDeferredValue, useImperativeHandle } from "react"
 import { trpc, type RouterOutputs } from "utils/trpc"
 import { openPanel } from "components/AppContext"
 import CheckIcon from "icons/done.svg"
@@ -10,15 +10,15 @@ import { editOverlay, editOverlaySetter } from "components/AppContext/editOverla
 import useLongPress from "./useLongPress"
 import { useCachedAlbum } from "client/sw/useSWCached"
 import useIsOnline from "utils/typedWs/useIsOnline"
+import { useVirtualizer } from "@tanstack/react-virtual"
 
 type AlbumListItem = {
 	id: string
 	name?: string
 }
 
-function AlbumItem({
+function AlbumItem ({
 	album,
-	enableSiblings,
 	onSelect,
 	onClick,
 	index,
@@ -26,7 +26,6 @@ function AlbumItem({
 	selectable,
 }: {
 	album: AlbumListItem
-	enableSiblings?: () => void
 	onSelect?: (album: Exclude<RouterOutputs["album"]["miniature"], null>) => void
 	onClick?: (album: Exclude<RouterOutputs["album"]["miniature"], null>) => void
 	index: number
@@ -34,24 +33,7 @@ function AlbumItem({
 	selectable: boolean
 }) {
 	const item = useRef<HTMLButtonElement>(null)
-	const {data} = trpc.album.miniature.useQuery({id: album.id})
-	
-	useEffect(() => {
-		if (!enableSiblings || !item.current) return
-
-		const observer = new IntersectionObserver(([entry]) => {
-			if (entry?.isIntersecting) {
-				startTransition(() => {
-					enableSiblings()
-				})
-			}
-		}, {
-			rootMargin: "0px 100px 0px 0px",
-		})
-		observer.observe(item.current)
-
-		return () => observer.disconnect()
-	}, [enableSiblings])
+	const { data } = trpc.album.miniature.useQuery({ id: album.id })
 
 	const isEmpty = !data?.cover
 	const trackCount = data?._count?.tracks ?? 0
@@ -62,14 +44,14 @@ function AlbumItem({
 	const onLong = selectable ? () => {
 		navigator.vibrate(1)
 		editOverlay.setState(
-			editOverlaySetter({type: "album", id: album.id}),
+			editOverlaySetter({ type: "album", id: album.id }),
 			queryClient
 		)
 	} : undefined
-	useLongPress({onLong, item})
+	useLongPress({ onLong, item })
 
 	const online = useIsOnline()
-	const {data: cached} = useCachedAlbum({id: album.id, enabled: !online})
+	const { data: cached } = useCachedAlbum({ id: album.id, enabled: !online })
 	const offline = !online && cached
 
 	return (
@@ -92,12 +74,12 @@ function AlbumItem({
 				}
 				data && onSelect?.(data)
 				const element = event.currentTarget
-				const {top, left, width} = element.getBoundingClientRect()
+				const { top, left, width } = element.getBoundingClientRect()
 				startTransition(() => {
 					openPanel("album", {
 						id: album.id,
 						name: data?.name || album.name,
-						rect: {top, left, width, src}
+						rect: { top, left, width, src }
 					}, queryClient)
 				})
 			}}
@@ -124,7 +106,7 @@ function AlbumItem({
 	)
 }
 
-export default forwardRef(function AlbumList({
+export default forwardRef(function AlbumList ({
 	albums,
 	onSelect,
 	onClick,
@@ -143,36 +125,75 @@ export default forwardRef(function AlbumList({
 	selected?: string
 	selectable?: boolean
 }, ref: ForwardedRef<HTMLDivElement>) {
-	const [enableUpTo, setEnableUpTo] = useState((scrollable && lines === 1) ? 3 : 6)
-
 	const _editViewState = editOverlay.useValue()
 	const editViewState = useDeferredValue(_editViewState)
 	const isSelection = selectable && editViewState.type === "album"
 
+	const main = useRef<HTMLDivElement>(null)
+	// eslint-disable-next-line react-hooks/rules-of-hooks -- `scrollable` never changes once the component is mounted
+	const virtualized = scrollable && useVirtualizer({
+		count: albums.length,
+		horizontal: true,
+		overscan: lines === 1 ? 0 : 2,
+		getScrollElement: () => main.current,
+		estimateSize: (index) => {
+			if (lines === 2 && index % 2 !== 0) return 0
+			return (window.innerWidth - 3 * 8) / 2 - 10 + 8
+		},
+		getItemKey: (index) => albums[index]!.id,
+	})
+
+	useImperativeHandle(ref, () => main.current!)
+
+	const items = virtualized && virtualized.getVirtualItems()
+
 	return (
-		<div className={classNames(styles.wrapper, {[styles.scrollable]: scrollable})} ref={ref}>
-			<ul className={
-				classNames(styles.main, {
-					[styles.loading]: loading,
-					[styles["lines-2"]]: lines === 2,
-				})
-			}>
-				{albums.map((album, i) => (
-					<li className={styles.item} key={album.id}>
-						{i <= enableUpTo && (
+		<div className={classNames(styles.wrapper, { [styles.scrollable]: scrollable })} ref={main}>
+			{virtualized && items && (
+				<div style={{ minWidth: virtualized.getTotalSize() }}>
+					<ul
+						className={classNames(styles.main, {
+							[styles.loading]: loading,
+							[styles["lines-2"]]: lines === 2,
+						})}
+						style={{ transform: `translateX(${items[0]?.start}px)` }}
+					>
+						{items.map((item) => (
+							<li className={styles.item} key={item.key} data-index={item.index}>
+								<AlbumItem
+									album={albums[item.index]!}
+									onSelect={onSelect}
+									onClick={onClick}
+									index={item.index}
+									selected={selected === item.key || (isSelection && editViewState.selection.some(({ id }) => id === item.key))}
+									selectable={selectable}
+								/>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+			{!virtualized && (
+				<ul className={
+					classNames(styles.main, {
+						[styles.loading]: loading,
+						[styles["lines-2"]]: lines === 2,
+					})
+				}>
+					{albums.map((album, i) => (
+						<li className={styles.item} key={album.id}>
 							<AlbumItem
 								album={album}
-								enableSiblings={i === enableUpTo && i !== albums.length - 1 ? () => setEnableUpTo(enableUpTo + 6) : undefined}
 								onSelect={onSelect}
 								onClick={onClick}
 								index={i}
-								selected={selected === album.id || (isSelection && editViewState.selection.some(({id}) => id === album.id))}
+								selected={selected === album.id || (isSelection && editViewState.selection.some(({ id }) => id === album.id))}
 								selectable={selectable}
 							/>
-						)}
-					</li>
-				))}
-			</ul>
+						</li>
+					))}
+				</ul>
+			)}
 		</div>
 	)
 })

--- a/src/components/AlbumList/index.tsx
+++ b/src/components/AlbumList/index.tsx
@@ -21,14 +21,12 @@ function AlbumItem ({
 	album,
 	onSelect,
 	onClick,
-	index,
 	selected,
 	selectable,
 }: {
 	album: AlbumListItem
 	onSelect?: (album: Exclude<RouterOutputs["album"]["miniature"], null>) => void
 	onClick?: (album: Exclude<RouterOutputs["album"]["miniature"], null>) => void
-	index: number
 	selected: boolean
 	selectable: boolean
 }) {
@@ -88,8 +86,6 @@ function AlbumItem ({
 				<img
 					src={src}
 					alt=""
-					loading={index > 1 ? "lazy" : undefined}
-					decoding={index > 1 ? "async" : undefined}
 				/>
 			)}
 			<p className={classNames(styles.span, {
@@ -164,7 +160,6 @@ export default forwardRef(function AlbumList ({
 									album={albums[item.index]!}
 									onSelect={onSelect}
 									onClick={onClick}
-									index={item.index}
 									selected={selected === item.key || (isSelection && editViewState.selection.some(({ id }) => id === item.key))}
 									selectable={selectable}
 								/>
@@ -186,7 +181,6 @@ export default forwardRef(function AlbumList ({
 								album={album}
 								onSelect={onSelect}
 								onClick={onClick}
-								index={i}
 								selected={selected === album.id || (isSelection && editViewState.selection.some(({ id }) => id === album.id))}
 								selectable={selectable}
 							/>

--- a/src/components/AlbumList/index.tsx
+++ b/src/components/AlbumList/index.tsx
@@ -10,7 +10,7 @@ import { editOverlay, editOverlaySetter } from "components/AppContext/editOverla
 import useLongPress from "./useLongPress"
 import { useCachedAlbum } from "client/sw/useSWCached"
 import useIsOnline from "utils/typedWs/useIsOnline"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual"
 
 type AlbumListItem = {
 	id: string
@@ -130,11 +130,17 @@ export default forwardRef(function AlbumList ({
 	const virtualized = scrollable && useVirtualizer({
 		count: albums.length,
 		horizontal: true,
-		overscan: lines === 1 ? 0 : 2,
+		overscan: 0,
 		getScrollElement: () => main.current,
 		estimateSize: (index) => {
 			if (lines === 2 && index % 2 !== 0) return 0
 			return (window.innerWidth - 3 * 8) / 2 - 10 + 8
+		},
+		rangeExtractor: (range) => {
+			if (lines === 1) return defaultRangeExtractor(range)
+			range.startIndex = Math.floor(range.startIndex / 2) * 2
+			range.endIndex = Math.ceil(range.endIndex / 2) * 2 + 1
+			return defaultRangeExtractor(range)
 		},
 		getItemKey: (index) => albums[index]!.id,
 	})

--- a/src/components/ArtistList/index.tsx
+++ b/src/components/ArtistList/index.tsx
@@ -21,14 +21,12 @@ function ArtistItem ({
 	artist,
 	onSelect,
 	onClick,
-	index,
 	selected,
 	selectable,
 }: {
 	artist: ArtistListItem
 	onSelect?: (artist: Exclude<RouterOutputs["artist"]["miniature"], null>) => void
 	onClick?: (artist: Exclude<RouterOutputs["artist"]["miniature"], null>) => void
-	index: number
 	selected: boolean
 	selectable?: boolean
 }) {
@@ -90,8 +88,6 @@ function ArtistItem ({
 						<img
 							src={src}
 							alt=""
-							loading={index > 2 ? "lazy" : undefined}
-							decoding={index > 2 ? "async" : undefined}
 						/>
 					)}
 				</div>
@@ -162,7 +158,6 @@ export default forwardRef(function ArtistList ({
 								artist={artists[item.index]!}
 								onSelect={onSelect}
 								onClick={onClick}
-								index={item.index}
 								selected={selected === item.key || (isSelection && editViewState.selection.some(({ id }) => id === item.key))}
 								selectable={selectable}
 							/>

--- a/src/components/ArtistList/index.tsx
+++ b/src/components/ArtistList/index.tsx
@@ -10,7 +10,7 @@ import useLongPress from "components/AlbumList/useLongPress"
 import { editOverlay, editOverlaySetter } from "components/AppContext/editOverlay"
 import { useCachedArtist } from "client/sw/useSWCached"
 import useIsOnline from "utils/typedWs/useIsOnline"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual"
 
 type ArtistListItem = {
 	id: string
@@ -129,11 +129,17 @@ export default forwardRef(function ArtistList ({
 	const virtualized = useVirtualizer({
 		count: artists.length,
 		horizontal: true,
-		overscan: lines === 1 ? 0 : 3,
+		overscan: 0,
 		getScrollElement: () => main.current,
 		estimateSize: (index) => {
 			if (lines === 3 && index % 3 !== 0) return 0
 			return (window.innerWidth - 4 * 8) / 3 + 8
+		},
+		rangeExtractor: (range) => {
+			if (lines === 1) return defaultRangeExtractor(range)
+			range.startIndex = Math.floor(range.startIndex / 3) * 3 - 3
+			range.endIndex = Math.ceil(range.endIndex / 3) * 3 + 2
+			return defaultRangeExtractor(range)
 		},
 		getItemKey: (index) => artists[index]!.id,
 	})

--- a/src/components/Header/Edit/Entities/Album.tsx
+++ b/src/components/Header/Edit/Entities/Album.tsx
@@ -18,42 +18,42 @@ import styles from "./index.module.css"
 
 type AlbumMiniature = RouterOutputs["album"]["miniature"]
 
-function aggregateTracks<K extends DeepKeyof<DeepExcludeNull<AlbumMiniature>>>(tracks: (AlbumMiniature | null | undefined)[], key: K): {readonly value: GetFieldType<DeepExcludeNull<AlbumMiniature>, K> | undefined, readonly unique: boolean} {
+function aggregateTracks<K extends DeepKeyof<DeepExcludeNull<AlbumMiniature>>> (tracks: (AlbumMiniature | null | undefined)[], key: K): { readonly value: GetFieldType<DeepExcludeNull<AlbumMiniature>, K> | undefined, readonly unique: boolean } {
 	const [first, ...rest] = (tracks.filter(Boolean) as Exclude<AlbumMiniature, null>[])
-	if (!first) return {value: undefined, unique: true}
+	if (!first) return { value: undefined, unique: true }
 	const value = getIn(first, key)
 	for (const track of rest) {
 		const trackValue = getIn(track, key)
-		if (trackValue !== value) return {value: undefined, unique: false}
+		if (trackValue !== value) return { value: undefined, unique: false }
 	}
-	return {value, unique: true}
+	return { value, unique: true }
 }
 
 const defaultArray = [] as never[]
-const defaultAggregate = {value: undefined, unique: undefined} as const
+const defaultAggregate = { value: undefined, unique: undefined } as const
 
-export default function EditAlbum({
+export default function EditAlbum ({
 	ids,
 	onDone,
 }: {
 	ids: string[]
 	onDone: () => void
 }) {
-	const {albums, isLoading} = trpc
-		.useQueries((t) => ids.map((id) => t.album.miniature({id})))
+	const { albums, isLoading } = trpc
+		.useQueries((t) => ids.map((id) => t.album.miniature({ id })))
 		.reduce<{
 			albums: (AlbumMiniature | undefined)[],
 			isLoading: boolean
-		}>((acc, {data, isLoading}) => {
+		}>((acc, { data, isLoading }) => {
 			acc.albums.push(data)
 			acc.isLoading = acc.isLoading || isLoading
 			return acc
-		}, {albums: [], isLoading: false})
+		}, { albums: [], isLoading: false })
 
 	const htmlId = useId()
 
 	const [nameState, setNameState] = useState<null | string>(albums[0]?.name ?? null)
-	useEffect(() => {setNameState(albums[0]?.name ?? null)}, [albums[0]?.name])
+	useEffect(() => { setNameState(albums[0]?.name ?? null) }, [albums[0]?.name])
 
 	const artistAggregate = isLoading ? defaultAggregate : aggregateTracks(albums, ["artist", "name"])
 	const [artistState, setArtistState] = useState(artistAggregate.value)
@@ -63,15 +63,15 @@ export default function EditAlbum({
 	const [coverState, setCoverState] = useState(coverAggregate.value)
 
 	const artistInput = useRef<HTMLInputElement>(null)
-	const {data: artistsRaw} = trpc.artist.searchable.useQuery()
-	const _artists = useAsyncInputStringDistance(artistInput, artistsRaw || defaultArray)
+	const { data: artistsRaw } = trpc.artist.searchable.useQuery()
+	const _artists = useAsyncInputStringDistance(artistInput, 10, artistsRaw || defaultArray)
 	const artists = _artists.length === 0 ? artistsRaw || defaultArray : _artists
 	const setArtistInputName = useCallback((name: string | undefined) => {
 		setArtistState(name)
 		artistInput.current!.value = name ?? ""
 		artistInput.current!.dispatchEvent(new Event("input"))
 	}, [])
-	useEffect(() => {setArtistInputName(artistAggregate.value)}, [setArtistInputName, artistAggregate.value])
+	useEffect(() => { setArtistInputName(artistAggregate.value) }, [setArtistInputName, artistAggregate.value])
 	artists.sort((a, b) => {
 		if (!artistSimplified) return 0
 		const aName = simplifiedName(a.name) === artistSimplified
@@ -99,15 +99,15 @@ export default function EditAlbum({
 		coverInput.current!.value = id ?? ""
 		coverInput.current!.dispatchEvent(new Event("input"))
 	}, [])
-	useEffect(() => {setCoverInputId(coverAggregate.value)}, [setCoverInputId, coverAggregate.value])
+	useEffect(() => { setCoverInputId(coverAggregate.value) }, [setCoverInputId, coverAggregate.value])
 
 	const isArtistModified = Boolean(artistSimplified && (!artistAggregate.value || artistSimplified !== simplifiedName(artistAggregate.value)))
 	const isCoverModified = Boolean(coverState && coverState !== coverAggregate.value)
 	const isSingleAlbum = albums.length === 1
 	const isNameModified = isSingleAlbum && Boolean(nameState && (!albums[0]?.name || simplifiedName(nameState) !== simplifiedName(albums[0].name)))
 
-	const {mutateAsync: updateAlbum} = trpc.edit.album.modify.useMutation()
-	const {mutateAsync: validateAlbum} = trpc.edit.album.validate.useMutation({retry: 0})
+	const { mutateAsync: updateAlbum } = trpc.edit.album.modify.useMutation()
+	const { mutateAsync: validateAlbum } = trpc.edit.album.validate.useMutation({ retry: 0 })
 	const [submitProgress, setSubmitProgress] = useState<number | null>(null)
 	const [errors, setErrors] = useState<string[]>([])
 	const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -157,11 +157,11 @@ export default function EditAlbum({
 					id: album!.id,
 					...editData
 				})
-				// @ts-expect-error -- this is fine
-				.finally((any) => {
-					increment()
-					return any
-				})
+					// @ts-expect-error -- this is fine
+					.finally((any) => {
+						increment()
+						return any
+					})
 			)
 		)
 		const rejections = allValidResponse.reduce<TRPCClientError<AppRouter["edit"]["track"]["validate"]>[]>((acc, res) => {
@@ -238,7 +238,7 @@ export default function EditAlbum({
 							loading
 						/>
 					</div>
-					
+
 					{/* Cover */}
 					<label htmlFor={`cover${htmlId}`} className={styles.label}>Cover</label>
 					<input
@@ -265,11 +265,11 @@ export default function EditAlbum({
 							}}
 						/>
 					</div>
-					
+
 					<div className={classNames(styles.full, styles.summary)}>
 						{isNameModified && (
 							<p>
-								<ModifIcon className={styles.icon}/>
+								<ModifIcon className={styles.icon} />
 								{`Rename album to "${nameState}"`}
 							</p>
 						)}
@@ -277,13 +277,13 @@ export default function EditAlbum({
 							<p>
 								{exactArtist && (
 									<>
-										<AssignIcon className={styles.icon}/>
+										<AssignIcon className={styles.icon} />
 										{`Assign artist "${artistState}" to ${albums.length} album${pluralize(albums.length)} (will not change tracks artist)`}
 									</>
 								)}
 								{!exactArtist && (
 									<>
-										<CreateIcon className={styles.icon}/>
+										<CreateIcon className={styles.icon} />
 										{`Create new artist "${artistState}" with ${albums.length} album${pluralize(albums.length)} (will not change tracks artist)`}
 									</>
 								)}
@@ -291,13 +291,13 @@ export default function EditAlbum({
 						)}
 						{isCoverModified && (
 							<p>
-								<ModifIcon className={styles.icon}/>
+								<ModifIcon className={styles.icon} />
 								{`Force selected cover on ${albums.length} album${pluralize(albums.length)}`}
 							</p>
 						)}
 						{errors.length > 0 && errors.map((error, index) => (
 							<p key={index} className={styles.error}>
-								<ErrorIcon className={styles.icon}/>
+								<ErrorIcon className={styles.icon} />
 								{error}
 							</p>
 						))}
@@ -307,7 +307,7 @@ export default function EditAlbum({
 						<SaveIcon className={styles.icon} />
 						Save
 						{submitProgress !== null && (
-							<div className={styles.progress} style={{"--progress": submitProgress} as CSSProperties}>
+							<div className={styles.progress} style={{ "--progress": submitProgress } as CSSProperties}>
 								<SaveIcon className={styles.icon} />
 								Save
 							</div>

--- a/src/components/Header/Edit/Entities/Track.tsx
+++ b/src/components/Header/Edit/Entities/Track.tsx
@@ -29,44 +29,44 @@ import getIn, { type DeepExcludeNull, type DeepKeyof, type GetFieldType } from "
 
 type TrackMiniature = RouterOutputs["track"]["miniature"]
 
-function aggregateTracks<K extends DeepKeyof<DeepExcludeNull<TrackMiniature>>>(tracks: (TrackMiniature | null | undefined)[], key: K): {readonly value: GetFieldType<DeepExcludeNull<TrackMiniature>, K> | undefined, readonly unique: boolean} {
+function aggregateTracks<K extends DeepKeyof<DeepExcludeNull<TrackMiniature>>> (tracks: (TrackMiniature | null | undefined)[], key: K): { readonly value: GetFieldType<DeepExcludeNull<TrackMiniature>, K> | undefined, readonly unique: boolean } {
 	const [first, ...rest] = (tracks.filter(Boolean) as Exclude<TrackMiniature, null>[])
-	if (!first) return {value: undefined, unique: true}
+	if (!first) return { value: undefined, unique: true }
 	const value = getIn(first, key)
 	for (const track of rest) {
 		const trackValue = getIn(track, key)
-		if (trackValue !== value) return {value: undefined, unique: false}
+		if (trackValue !== value) return { value: undefined, unique: false }
 	}
-	return {value, unique: true}
+	return { value, unique: true }
 }
 
 const defaultArray = [] as never[]
-const defaultAggregate = {value: undefined, unique: undefined} as const
+const defaultAggregate = { value: undefined, unique: undefined } as const
 
-export default function EditTrack({
+export default function EditTrack ({
 	ids,
 	onDone,
 }: {
 	ids: string[]
 	onDone: () => void
 }) {
-	const {tracks, isLoading} = trpc
-		.useQueries((t) => ids.map((id) => t.track.miniature({id})))
+	const { tracks, isLoading } = trpc
+		.useQueries((t) => ids.map((id) => t.track.miniature({ id })))
 		.reduce<{
 			tracks: (TrackMiniature | undefined)[],
 			isLoading: boolean
-		}>((acc, {data, isLoading}) => {
+		}>((acc, { data, isLoading }) => {
 			acc.tracks.push(data)
 			acc.isLoading = acc.isLoading || isLoading
 			return acc
-		}, {tracks: [], isLoading: false})
+		}, { tracks: [], isLoading: false })
 
 	const htmlId = useId()
 
 	const [nameState, setNameState] = useState<null | string>(tracks[0]?.name ?? null)
-	useEffect(() => {setNameState(tracks[0]?.name ?? null)}, [tracks[0]?.name])
+	useEffect(() => { setNameState(tracks[0]?.name ?? null) }, [tracks[0]?.name])
 	const [positionState, setPositionState] = useState<null | number>(tracks[0]?.position ?? null)
-	useEffect(() => {setPositionState(tracks[0]?.position ?? null)}, [tracks[0]?.position])
+	useEffect(() => { setPositionState(tracks[0]?.position ?? null) }, [tracks[0]?.position])
 
 	const albumAggregate = isLoading ? defaultAggregate : aggregateTracks(tracks, ["album", "name"])
 	const [albumState, setAlbumState] = useState(albumAggregate.value)
@@ -80,8 +80,8 @@ export default function EditTrack({
 	const [coverState, setCoverState] = useState(coverAggregate.value)
 
 	const artistInput = useRef<HTMLInputElement>(null)
-	const {data: artistsRaw} = trpc.artist.searchable.useQuery()
-	const _artists = useAsyncInputStringDistance(artistInput, artistsRaw || defaultArray)
+	const { data: artistsRaw } = trpc.artist.searchable.useQuery()
+	const _artists = useAsyncInputStringDistance(artistInput, 10, artistsRaw || defaultArray)
 	const artists = _artists.length === 0 ? artistsRaw || defaultArray : _artists
 	const setArtistInputName = useCallback((name: string | undefined) => {
 		setArtistState(name)
@@ -89,7 +89,7 @@ export default function EditTrack({
 		artistInput.current!.dispatchEvent(new Event("input"))
 		albumInput.current!.dispatchEvent(new Event("input"))
 	}, [])
-	useEffect(() => {setArtistInputName(artistAggregate.value)}, [setArtistInputName, artistAggregate.value])
+	useEffect(() => { setArtistInputName(artistAggregate.value) }, [setArtistInputName, artistAggregate.value])
 	artists.sort((a, b) => {
 		if (!albumSimplified && !artistSimplified) return 0
 		const aName = simplifiedName(a.name) === artistSimplified
@@ -121,23 +121,23 @@ export default function EditTrack({
 	const exactArtist = Boolean(artistSimplified && artists[0] && artistSimplified === simplifiedName(artists[0].name))
 
 	const albumInput = useRef<HTMLInputElement>(null)
-	const {data: albumsRaw} = trpc.album.searchable.useQuery()
+	const { data: albumsRaw } = trpc.album.searchable.useQuery()
 	const fakeAlbumInput = useRef<HTMLInputElement>({} as HTMLInputElement)
 	useEffect(() => {
 		const input = albumInput.current!
 		fakeAlbumInput.current = {
-			get value() {
+			get value () {
 				return `${input.value} ${artistInput.current!.value}`
 			},
-			get addEventListener() {
+			get addEventListener () {
 				return input.addEventListener.bind(input)
 			},
-			get removeEventListener() {
+			get removeEventListener () {
 				return input.removeEventListener.bind(input)
 			},
 		} as HTMLInputElement
 	}, [])
-	const __albums = useAsyncInputStringDistance(fakeAlbumInput, albumsRaw || defaultArray, ["name", "artists"])
+	const __albums = useAsyncInputStringDistance(fakeAlbumInput, 10, albumsRaw || defaultArray, ["name", "artists"])
 	const _albums = __albums.length === 0 ? albumsRaw || defaultArray : __albums
 	const albums = useDeferredValue(_albums)
 	const setAlbumInputName = useCallback((name: string | undefined, artistName?: string) => {
@@ -146,7 +146,7 @@ export default function EditTrack({
 		if (typeof artistName === "string") setArtistInputName(artistName)
 		albumInput.current!.dispatchEvent(new Event("input"))
 	}, [setArtistInputName])
-	useEffect(() => {setAlbumInputName(albumAggregate.value)}, [setAlbumInputName, albumAggregate.value])
+	useEffect(() => { setAlbumInputName(albumAggregate.value) }, [setAlbumInputName, albumAggregate.value])
 	albums.sort((a, b) => {
 		// if an album has exact title and artist, put it first. If an album has exact title, put it second
 		if (!albumSimplified && !artistSimplified) return 0
@@ -184,7 +184,7 @@ export default function EditTrack({
 		coverInput.current!.value = id ?? ""
 		coverInput.current!.dispatchEvent(new Event("input"))
 	}, [])
-	useEffect(() => {setCoverInputId(coverAggregate.value)}, [setCoverInputId, coverAggregate.value])
+	useEffect(() => { setCoverInputId(coverAggregate.value) }, [setCoverInputId, coverAggregate.value])
 
 	const isAlbumModified = Boolean(albumSimplified && (!albumAggregate.value || albumSimplified !== simplifiedName(albumAggregate.value)))
 	const isArtistModified = Boolean(artistSimplified && (!artistAggregate.value || artistSimplified !== simplifiedName(artistAggregate.value)))
@@ -193,8 +193,8 @@ export default function EditTrack({
 	const isNameModified = isSingleTrack && Boolean(nameState && (!tracks[0]?.name || simplifiedName(nameState) !== simplifiedName(tracks[0].name)))
 	const isPositionModified = isSingleTrack && Boolean(positionState !== null && positionState !== tracks[0]?.position)
 
-	const {mutateAsync: updateTrack} = trpc.edit.track.modify.useMutation()
-	const {mutateAsync: validateTrack} = trpc.edit.track.validate.useMutation({retry: 0})
+	const { mutateAsync: updateTrack } = trpc.edit.track.modify.useMutation()
+	const { mutateAsync: validateTrack } = trpc.edit.track.validate.useMutation({ retry: 0 })
 	const [submitProgress, setSubmitProgress] = useState<number | null>(null)
 	const [errors, setErrors] = useState<string[]>([])
 	const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -261,11 +261,11 @@ export default function EditTrack({
 					id: track!.id,
 					...editData
 				})
-				// @ts-expect-error -- this is fine
-				.finally((any) => {
-					increment()
-					return any
-				})
+					// @ts-expect-error -- this is fine
+					.finally((any) => {
+						increment()
+						return any
+					})
 			)
 		)
 		const rejections = allValidResponse.reduce<TRPCClientError<AppRouter["edit"]["track"]["validate"]>[]>((acc, res) => {
@@ -384,7 +384,7 @@ export default function EditTrack({
 							selectable={false}
 						/>
 					</div>
-					
+
 					{/* Cover */}
 					<label htmlFor={`cover${htmlId}`} className={styles.label}>Cover</label>
 					<input
@@ -412,17 +412,17 @@ export default function EditTrack({
 							}}
 						/>
 					</div>
-					
+
 					<div className={classNames(styles.full, styles.summary)}>
 						{isNameModified && (
 							<p>
-								<ModifIcon className={styles.icon}/>
+								<ModifIcon className={styles.icon} />
 								{`Rename track to "${nameState}"`}
 							</p>
 						)}
 						{isPositionModified && (
 							<p>
-								<ModifIcon className={styles.icon}/>
+								<ModifIcon className={styles.icon} />
 								{`Set track position to #${String(positionState).padStart(2, "0")}`}
 							</p>
 						)}
@@ -430,13 +430,13 @@ export default function EditTrack({
 							<p>
 								{exactAlbum && (
 									<>
-										<AssignIcon className={styles.icon}/>
+										<AssignIcon className={styles.icon} />
 										{`Add ${tracks.length} track${pluralize(tracks.length)} to "${albumState}" album`}
 									</>
 								)}
 								{!exactAlbum && (
 									<>
-										<CreateIcon className={styles.icon}/>
+										<CreateIcon className={styles.icon} />
 										{`Create new album "${albumState}" with ${tracks.length} track${pluralize(tracks.length)}`}
 									</>
 								)}
@@ -446,13 +446,13 @@ export default function EditTrack({
 							<p>
 								{exactArtist && (
 									<>
-										<AssignIcon className={styles.icon}/>
+										<AssignIcon className={styles.icon} />
 										{`Assign artist "${artistState}" to ${tracks.length} track${pluralize(tracks.length)}`}
 									</>
 								)}
 								{!exactArtist && (
 									<>
-										<CreateIcon className={styles.icon}/>
+										<CreateIcon className={styles.icon} />
 										{`Create new artist "${artistState}" with ${tracks.length} track${pluralize(tracks.length)}`}
 									</>
 								)}
@@ -460,13 +460,13 @@ export default function EditTrack({
 						)}
 						{isCoverModified && (
 							<p>
-								<ModifIcon className={styles.icon}/>
+								<ModifIcon className={styles.icon} />
 								{`Force selected cover on ${tracks.length} track${pluralize(tracks.length)}`}
 							</p>
 						)}
 						{errors.length > 0 && errors.map((error, index) => (
 							<p key={index} className={styles.error}>
-								<ErrorIcon className={styles.icon}/>
+								<ErrorIcon className={styles.icon} />
 								{error}
 							</p>
 						))}
@@ -476,7 +476,7 @@ export default function EditTrack({
 						<SaveIcon className={styles.icon} />
 						Save
 						{submitProgress !== null && (
-							<div className={styles.progress} style={{"--progress": submitProgress} as CSSProperties}>
+							<div className={styles.progress} style={{ "--progress": submitProgress } as CSSProperties}>
 								<SaveIcon className={styles.icon} />
 								Save
 							</div>

--- a/src/components/Header/Playlist/index.tsx
+++ b/src/components/Header/Playlist/index.tsx
@@ -2,7 +2,7 @@ import { type ForwardedRef, forwardRef, startTransition, useImperativeHandle, us
 import { useShowHome } from "components/AppContext"
 import styles from "./index.module.css"
 import TrackList, { useVirtualTracks } from "components/TrackList"
-import { RouterOutputs, trpc } from "utils/trpc"
+import { type RouterOutputs, trpc } from "utils/trpc"
 import { useCurrentTrackDetails, useRemoveFromPlaylist, useReorderPlaylist, useSetPlaylist } from "client/db/useMakePlaylist"
 import Panel from "../Panel"
 import CoverImages from "components/NowPlaying/Cover/Images"

--- a/src/components/Header/Playlist/index.tsx
+++ b/src/components/Header/Playlist/index.tsx
@@ -1,4 +1,4 @@
-import { type ForwardedRef, forwardRef, startTransition, useImperativeHandle, useRef } from "react"
+import { type ForwardedRef, forwardRef, startTransition, useImperativeHandle, useRef, useCallback } from "react"
 import { useShowHome } from "components/AppContext"
 import styles from "./index.module.css"
 import TrackList, { useVirtualTracks } from "components/TrackList"
@@ -71,6 +71,25 @@ export default forwardRef(function PlaylistView ({
 		virtual: true,
 	})
 
+	const { tracks } = trackListProps
+
+	const onReorder = useCallback((from: number, to: number) =>
+		reorderPlaylist(from, to, id),
+		[id, reorderPlaylist]
+	)
+
+	const onQuickSwipe = useCallback((track: { id: string }) =>
+		deleteFromPlaylist(track.id, id),
+		[id, deleteFromPlaylist]
+	)
+
+	const onClick = useCallback((trackId: string) => {
+		if (_name && tracks) startTransition(() => {
+			setPlaylist(_name, tracks, id, trackId)
+			showHome("home")
+		})
+	}, [_name, id, setPlaylist, showHome, tracks])
+
 	return (
 		<Panel
 			ref={parent}
@@ -87,18 +106,9 @@ export default forwardRef(function PlaylistView ({
 		>
 			<TrackList
 				{...trackListProps}
-				onReorder={(oldIndex, newIndex) => {
-					reorderPlaylist(oldIndex, newIndex, id)
-				}}
-				onClick={(trackId) => {
-					if (_name && trackListProps.tracks) startTransition(() => {
-						setPlaylist(_name, trackListProps.tracks, id, trackId)
-						showHome("home")
-					})
-				}}
-				quickSwipeAction={(track) => {
-					deleteFromPlaylist(track.id, id)
-				}}
+				onReorder={onReorder}
+				onClick={onClick}
+				quickSwipeAction={onQuickSwipe}
 				quickSwipeIcon={DeleteIcon}
 				quickSwipeDeleteAnim
 			/>

--- a/src/components/Header/Search/index.tsx
+++ b/src/components/Header/Search/index.tsx
@@ -13,7 +13,7 @@ import PlaylistList from "components/PlaylistList"
 
 const defaultArray = [] as never[]
 
-export default function Search({
+export default function Search ({
 	open,
 	z,
 }: {
@@ -28,17 +28,17 @@ export default function Search({
 	const albumList = useRef<HTMLDivElement>(null)
 	const [enabled, setEnabled] = useState(false)
 
-	const {data: tracksRaw} = trpc.track.searchable.useQuery(undefined, {enabled})
-	const {data: albumsRaw} = trpc.album.searchable.useQuery(undefined, {enabled})
-	const {data: artistsRaw} = trpc.artist.searchable.useQuery(undefined, {enabled})
-	const {data: genresRaw} = trpc.genre.list.useQuery(undefined, {enabled})
-	const {data: playlistsRaw} = trpc.playlist.searchable.useQuery(undefined, {enabled})
+	const { data: tracksRaw } = trpc.track.searchable.useQuery(undefined, { enabled })
+	const { data: albumsRaw } = trpc.album.searchable.useQuery(undefined, { enabled })
+	const { data: artistsRaw } = trpc.artist.searchable.useQuery(undefined, { enabled })
+	const { data: genresRaw } = trpc.genre.list.useQuery(undefined, { enabled })
+	const { data: playlistsRaw } = trpc.playlist.searchable.useQuery(undefined, { enabled })
 
-	const tracks = useAsyncInputStringDistance(input, tracksRaw || defaultArray, ["name", "artist.name", "album.name"])
-	const albums = useAsyncInputStringDistance(input, albumsRaw || defaultArray, ["name", "artists"])
-	const artists = useAsyncInputStringDistance(input, artistsRaw || defaultArray)
-	const genres = useAsyncInputStringDistance(input, genresRaw || defaultArray)
-	const playlists = useAsyncInputStringDistance(input, playlistsRaw || defaultArray, ["name", "artists"])
+	const tracks = useAsyncInputStringDistance(input, 25, tracksRaw || defaultArray, ["name", "artist.name", "album.name"])
+	const albums = useAsyncInputStringDistance(input, 44, albumsRaw || defaultArray, ["name", "artists"])
+	const artists = useAsyncInputStringDistance(input, 45, artistsRaw || defaultArray)
+	const genres = useAsyncInputStringDistance(input, 21, genresRaw || defaultArray)
+	const playlists = useAsyncInputStringDistance(input, 6, playlistsRaw || defaultArray, ["name", "artists"])
 
 	const [showPast, setShowPast] = useState(true)
 
@@ -59,13 +59,13 @@ export default function Search({
 			if (input.current) {
 				input.current.focus()
 			}
-		}, {once: true, signal: controller.signal})
+		}, { once: true, signal: controller.signal })
 		head.current.addEventListener("submit", (e) => {
 			e.preventDefault()
 			if (input.current) {
 				input.current.blur()
 			}
-		}, {signal: controller.signal})
+		}, { signal: controller.signal })
 		input.current.addEventListener("focus", () => {
 			results.current?.scroll({
 				top: 0,
@@ -79,7 +79,7 @@ export default function Search({
 				left: 0,
 				behavior: "smooth"
 			})
-		}, {signal: controller.signal, passive: true})
+		}, { signal: controller.signal, passive: true })
 		let lastScroll = 0
 		results.current.addEventListener("scroll", () => {
 			const scroll = results.current?.scrollTop || 0
@@ -87,12 +87,12 @@ export default function Search({
 				input.current?.blur()
 			}
 			lastScroll = scroll
-		}, {signal: controller.signal, passive: true})
+		}, { signal: controller.signal, passive: true })
 		return () => controller.abort()
 	}, [showPast, open])
 
-	const {data: latestSearches = []} = usePastSearchesQuery()
-	const {mutate: onSelect} = usePastSearchesMutation()
+	const { data: latestSearches = [] } = usePastSearchesQuery()
+	const { mutate: onSelect } = usePastSearchesMutation()
 
 	const id = useId()
 	return (
@@ -102,12 +102,12 @@ export default function Search({
 				className={styles.head}
 				data-open={open}
 				id={id}
-				style={{"--z": z} as CSSProperties}
+				style={{ "--z": z } as CSSProperties}
 			>
 				<input
 					ref={input}
 					type="text"
-					onFocus={!enabled ? (() => {setEnabled(true)}) : undefined}
+					onFocus={!enabled ? (() => { setEnabled(true) }) : undefined}
 					onChange={() => input.current?.value ? setShowPast(false) : setShowPast(true)}
 					defaultValue=""
 					inputMode="search"
@@ -118,7 +118,7 @@ export default function Search({
 				className={styles.results}
 				data-open={open}
 				htmlFor={id}
-				style={{"--z": z} as CSSProperties}
+				style={{ "--z": z } as CSSProperties}
 			>
 				{showPast && latestSearches.length > 0 && (
 					<div>
@@ -133,8 +133,8 @@ export default function Search({
 						<SectionTitle className={styles.sectionTitle}>Artists</SectionTitle>
 						<ArtistList
 							ref={artistList}
-							artists={artists.slice(0, 21)}
-							onSelect={({id}) => onSelect({type: "artist", id})}
+							artists={artists}
+							onSelect={({ id }) => onSelect({ type: "artist", id })}
 							loading={!artists.length}
 						/>
 					</div>
@@ -145,8 +145,8 @@ export default function Search({
 						<AlbumList
 							ref={albumList}
 							scrollable
-							albums={albums.slice(0, 28)}
-							onSelect={({id}) => onSelect({type: "album", id})}
+							albums={albums}
+							onSelect={({ id }) => onSelect({ type: "album", id })}
 							loading={!albums.length}
 						/>
 					</div>
@@ -155,8 +155,8 @@ export default function Search({
 					<div>
 						<SectionTitle className={styles.sectionTitle}>Genres</SectionTitle>
 						<GenreList
-							genres={genres.slice(0, 21)}
-							onSelect={({id}) => onSelect({type: "genre", id})}
+							genres={genres}
+							onSelect={({ id }) => onSelect({ type: "genre", id })}
 						/>
 					</div>
 				)}
@@ -164,8 +164,8 @@ export default function Search({
 					<div>
 						<SectionTitle className={styles.sectionTitle}>Playlists</SectionTitle>
 						<PlaylistList
-							playlists={playlists.slice(0, 6)}
-							onSelect={({id}) => onSelect({type: "playlist", id})}
+							playlists={playlists}
+							onSelect={({ id }) => onSelect({ type: "playlist", id })}
 						/>
 					</div>
 				)}
@@ -173,8 +173,8 @@ export default function Search({
 					<div>
 						<SectionTitle className={styles.sectionTitle}>Tracks</SectionTitle>
 						<TrackList
-							tracks={tracks.slice(0, 25)}
-							onSelect={({id}) => onSelect({type: "track", id})}
+							tracks={tracks}
+							onSelect={({ id }) => onSelect({ type: "track", id })}
 						/>
 					</div>
 				)}

--- a/src/components/Header/Search/useAsyncInputFilter.tsx
+++ b/src/components/Header/Search/useAsyncInputFilter.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState, useEffect, type RefObject, useMemo, startTransition } from "react"
 
-type MinimumWorkerDataObject = {name: string}
+type MinimumWorkerDataObject = { name: string }
 
 type Obj = {
-	[key: string]: Obj | string | Obj[] | string[];
+	[key: string]: Obj | string | Obj[] | string[]
 }
 
-function getIn(obj: Obj | string, [key, ...path]: string[]): string {
+function getIn (obj: Obj | string, [key, ...path]: string[]): string {
 	if (typeof obj === "string")
 		return obj
 	if (!key)
@@ -19,8 +19,9 @@ function getIn(obj: Obj | string, [key, ...path]: string[]): string {
 	return getIn(next, path)
 }
 
-export default function useAsyncInputStringDistance<T extends MinimumWorkerDataObject>(
+export default function useAsyncInputStringDistance<T extends MinimumWorkerDataObject> (
 	inputRef: RefObject<HTMLInputElement>,
+	size: number,
 	dataList: T[],
 	keys: string[] = ["name"],
 ): T[] {
@@ -41,7 +42,7 @@ export default function useAsyncInputStringDistance<T extends MinimumWorkerDataO
 	const nextValue = useRef<string | null>(null)
 
 	useEffect(() => {
-		const {current: inputMemo} = inputRef
+		const { current: inputMemo } = inputRef
 		if (!inputMemo) return
 
 		const workerMemo = new Worker(
@@ -85,7 +86,7 @@ export default function useAsyncInputStringDistance<T extends MinimumWorkerDataO
 		const { current: inputMemo } = inputRef
 		if (!worker.current || !inputMemo) return
 
-		worker.current.postMessage({ type: "list", list: namedObjects })
+		worker.current.postMessage({ type: "list", list: namedObjects, size })
 		let lastInputValue: string
 		const onInput = () => {
 			if (worker.current && inputMemo.value) {
@@ -109,7 +110,7 @@ export default function useAsyncInputStringDistance<T extends MinimumWorkerDataO
 		return () => {
 			inputMemo.removeEventListener("input", onInput)
 		}
-	}, [namedObjects, inputRef])
+	}, [namedObjects, size, inputRef])
 
 	return list
 }

--- a/src/components/Header/Search/worker/asyncInput.worker.ts
+++ b/src/components/Header/Search/worker/asyncInput.worker.ts
@@ -14,7 +14,7 @@ type NamedInterface = {
 
 const memoizedInputDistances = new Map<string, Map<string, DistanceObject>>()
 
-function getMemoized(input: string, candidate: string): DistanceObject | null {
+function getMemoized (input: string, candidate: string): DistanceObject | null {
 	const inputDistances = memoizedInputDistances.get(input)
 	if (inputDistances) {
 		const candidateDistances = inputDistances.get(candidate)
@@ -25,7 +25,7 @@ function getMemoized(input: string, candidate: string): DistanceObject | null {
 	return null
 }
 
-function setMemoized(input: string, candidate: string, object: DistanceObject) {
+function setMemoized (input: string, candidate: string, object: DistanceObject) {
 	let inputDistances = memoizedInputDistances.get(input)
 	if (!inputDistances) {
 		inputDistances = new Map()
@@ -34,11 +34,11 @@ function setMemoized(input: string, candidate: string, object: DistanceObject) {
 	inputDistances.set(candidate, object)
 }
 
-function cleanupString(str: string) {
+function cleanupString (str: string) {
 	return str.normalize("NFD").replace(/\p{Diacritic}/gu, "")
 }
 
-function classify(_input: string, _candidate: string): DistanceObject {
+function classify (_input: string, _candidate: string): DistanceObject {
 	const input = cleanupString(_input)
 	const candidate = cleanupString(_candidate)
 	const { length: inputMax } = input
@@ -54,7 +54,7 @@ function classify(_input: string, _candidate: string): DistanceObject {
 	}
 }
 
-function getDistances(input: string, candidate: string): DistanceObject {
+function getDistances (input: string, candidate: string): DistanceObject {
 	const memoized = getMemoized(input, candidate)
 	if (memoized) {
 		return memoized
@@ -65,12 +65,14 @@ function getDistances(input: string, candidate: string): DistanceObject {
 }
 
 let dataList: NamedInterface[] = []
+let requestedSize = 50
 
-function handleList({ list }: { list: NamedInterface[] }) {
+function handleList ({ list, size }: { list: NamedInterface[], size: number }) {
 	dataList = list
+	requestedSize = size
 }
 
-function handleInput({ input }: { input: string }) {
+function handleInput ({ input }: { input: string }) {
 	const list = dataList.sort((aItem, bItem) => {
 		const aName = aItem.name
 		const bName = bItem.name
@@ -85,15 +87,15 @@ function handleInput({ input }: { input: string }) {
 		return a.levenshtein - b.levenshtein
 	})
 
-	const res = new Uint16Array(list.slice(0, 50).map(({ id }) => id))
+	const res = new Uint16Array(list.slice(0, requestedSize).map(({ id }) => id))
 	postMessage({ input, list: res }, { transfer: [res.buffer] })
 }
 
 onmessage = function ({ data }: {
 	data:
-	| { type: "list"; list: NamedInterface[] }
+	| { type: "list"; list: NamedInterface[]; size: number }
 	| { type: "input"; input: string }
-	| { type: "never"; }
+	| { type: "never" }
 }) {
 	switch (data.type) {
 		case "list":

--- a/src/components/NowPlaying/index.tsx
+++ b/src/components/NowPlaying/index.tsx
@@ -1,6 +1,6 @@
 import { usePlaylist, useRemoveFromPlaylist, useReorderPlaylist, useSetPlaylistIndex } from "client/db/useMakePlaylist"
 import TrackList, { useVirtualTracks } from "components/TrackList"
-import { memo, startTransition, useRef } from "react"
+import { memo, startTransition, useCallback, useRef } from "react"
 import DeleteIcon from "icons/playlist_remove.svg"
 import Cover from "./Cover"
 import styles from "./index.module.css"
@@ -18,22 +18,35 @@ export default memo(function NowPlaying () {
 		parent,
 		orderable: true,
 		virtual: true,
+		exposeScrollFn: true,
 	})
+	const { tracks } = trackListProps
+
+	const onTrackClick = useCallback((id: string) => startTransition(() => {
+		setPlaylistIndex(tracks.findIndex((item) => item.id === id))
+	}), [tracks, setPlaylistIndex])
+
+	const onReorder = useCallback((from: number, to: number) =>
+		reorderPlaylist(from, to, data?.id),
+		[data?.id, reorderPlaylist]
+	)
+
+	const onQuickSwipe = useCallback((track: { id: string }) =>
+		deleteFromPlaylist(track.id, data?.id),
+		[data?.id, deleteFromPlaylist]
+	)
 
 	if (!data) return null
 	const { current, id } = data
-	const { tracks } = trackListProps
 
 	return (
 		<div className={styles.main} ref={parent}>
 			<Cover />
 			<TrackList
 				current={current}
-				onClick={(id) => startTransition(() => {
-					setPlaylistIndex(tracks.findIndex((item) => item.id === id))
-				})}
-				onReorder={(from, to) => reorderPlaylist(from, to, id)}
-				quickSwipeAction={(track) => deleteFromPlaylist(track.id, id)}
+				onClick={onTrackClick}
+				onReorder={onReorder}
+				quickSwipeAction={onQuickSwipe}
 				quickSwipeIcon={DeleteIcon}
 				quickSwipeDeleteAnim
 				{...trackListProps}

--- a/src/components/NowPlaying/index.tsx
+++ b/src/components/NowPlaying/index.tsx
@@ -1,4 +1,4 @@
-import { type Playlist, usePlaylist, useRemoveFromPlaylist, useReorderPlaylist, useSetPlaylistIndex } from "client/db/useMakePlaylist"
+import { usePlaylist, useRemoveFromPlaylist, useReorderPlaylist, useSetPlaylistIndex } from "client/db/useMakePlaylist"
 import TrackList, { useVirtualTracks } from "components/TrackList"
 import { memo, startTransition, useRef } from "react"
 import DeleteIcon from "icons/playlist_remove.svg"
@@ -6,19 +6,23 @@ import Cover from "./Cover"
 import styles from "./index.module.css"
 import AddMoreButton from "./AddMoreButton"
 
-function NowPlayingLoaded ({ data }: { data: Playlist }) {
+export default memo(function NowPlaying () {
+	const { data } = usePlaylist()
 	const reorderPlaylist = useReorderPlaylist()
 	const { setPlaylistIndex } = useSetPlaylistIndex()
 	const deleteFromPlaylist = useRemoveFromPlaylist()
 	const parent = useRef<HTMLDivElement>(null)
-	const { tracks, current, id } = data
 
 	const trackListProps = useVirtualTracks({
-		tracks,
+		tracks: data?.tracks ?? [],
 		parent,
 		orderable: true,
 		virtual: true,
 	})
+
+	if (!data) return null
+	const { current, id } = data
+	const { tracks } = trackListProps
 
 	return (
 		<div className={styles.main} ref={parent}>
@@ -34,7 +38,7 @@ function NowPlayingLoaded ({ data }: { data: Playlist }) {
 				quickSwipeDeleteAnim
 				{...trackListProps}
 			/>
-			{data.tracks.length < 100 && (
+			{tracks.length < 100 && (
 				<AddMoreButton
 					id={id}
 					tracks={tracks}
@@ -42,10 +46,4 @@ function NowPlayingLoaded ({ data }: { data: Playlist }) {
 			)}
 		</div>
 	)
-}
-
-export default memo(function NowPlaying () {
-	const { data } = usePlaylist()
-	if (!data) return null
-	return <NowPlayingLoaded data={data} />
 })

--- a/src/components/Player/SlidingText/index.tsx
+++ b/src/components/Player/SlidingText/index.tsx
@@ -6,7 +6,7 @@ import styles from "./index.module.css"
 import { useGetCurrentIndex } from "client/db/useMakePlaylist"
 import { useQueryClient } from "@tanstack/react-query"
 
-export default memo(function SlidingText({
+export default memo(function SlidingText ({
 	item,
 	className,
 }: {
@@ -35,14 +35,12 @@ export default memo(function SlidingText({
 	const main = mainView.useValue()
 	const getCurrentIndex = useGetCurrentIndex()
 	const scrollToCurrent = useCallback(() => {
+		// @ts-expect-error -- this is a hack to expose the scroll function
+		const scrollToIndex = window._scrollNowPlayingToIndex as ((index: number) => void) | undefined
+		if (!scrollToIndex) return
 		const index = getCurrentIndex()
 		if (typeof index === "undefined") return
-		const element = document.querySelector(`[data-index="${index}"]`)
-		if (!element) return
-		element.scrollIntoView({
-			behavior: "smooth",
-			block: "center",
-		})
+		scrollToIndex(index)
 	}, [getCurrentIndex])
 	useEffect(() => {
 		if (main !== "home") return
@@ -110,7 +108,7 @@ export default memo(function SlidingText({
 	)
 
 	return (
-		<div className={classNames(styles.main, className, {[styles.sliding as string]: separator})}>
+		<div className={classNames(styles.main, className, { [styles.sliding as string]: separator })}>
 			<div className={styles.wrapper}>
 				<div className={styles.span} ref={span} key="base">
 					{content}

--- a/src/components/TrackList/index.module.css
+++ b/src/components/TrackList/index.module.css
@@ -1,11 +1,12 @@
 .main {
-
+	width: 100%;
+	position: relative;
 }
 .item {
 	width: 100%;
-}
-.placeholder {
-	height: calc(48px + 2 * 8px + 1px);
+	--virtual-y: 0px;
+	transform: translateY(var(--virtual-y));
+	z-index: 0;
 }
 
 .wrapper {
@@ -34,6 +35,7 @@
 
 .drag {
 	position: relative;
+	z-index: 1;
 	--y: 0px;
 	--bg-y: 0;
 }
@@ -52,10 +54,10 @@
 	contain: layout style inline-size;
 }
 .slide {
-	transform: translateY(100%);
+	transform: translateY(calc(var(--virtual-y) + 100%));
 }
 .drag ~ .slide {
-	transform: translateY(-100%);
+	transform: translateY(calc(var(--virtual-y) + -100%));
 }
 
 .fav {

--- a/src/components/TrackList/index.module.css
+++ b/src/components/TrackList/index.module.css
@@ -1,12 +1,8 @@
 .main {
-	width: 100%;
-	position: relative;
+
 }
 .item {
 	width: 100%;
-	--virtual-y: 0px;
-	transform: translateY(var(--virtual-y));
-	z-index: 0;
 }
 
 .wrapper {
@@ -54,10 +50,10 @@
 	contain: layout style inline-size;
 }
 .slide {
-	transform: translateY(calc(var(--virtual-y) + 100%));
+	transform: translateY(100%);
 }
 .drag ~ .slide {
-	transform: translateY(calc(var(--virtual-y) + -100%));
+	transform: translateY(-100%);
 }
 
 .fav {

--- a/src/components/TrackList/index.tsx
+++ b/src/components/TrackList/index.tsx
@@ -206,11 +206,16 @@ const TrackItem = memo(function _TrackItem ({
 	)
 })
 
-export function useVirtualTracks<T extends { id: string }[]> ({ virtual, parent, orderable, tracks }: {
+export function useVirtualTracks<T extends { id: string }[]> ({
+	virtual,
+	parent,
+	orderable,
+	tracks,
+}: {
 	virtual?: boolean
 	parent: RefObject<HTMLElement>
 	orderable?: boolean
-	tracks: T
+	tracks: T,
 }) {
 	const staticOrderable = useRef(orderable)
 	// eslint-disable-next-line react-hooks/rules-of-hooks -- this should be OK as `orderable` doesn't change once a component is mounted

--- a/src/components/TrackList/index.tsx
+++ b/src/components/TrackList/index.tsx
@@ -338,30 +338,31 @@ export default function TrackList ({
 				}}
 			>
 				{virtualizer && (
-					<div style={{ height: `${virtualTop}px` }} />
+					<div style={{ transform: `translateY(${virtualTop}px)` }} >
+						{virtualizer((virtualItem) => (
+							<li
+								className={styles.item}
+								key={virtualItem.key}
+								data-index={virtualItem.index}
+							>
+								<TrackItem
+									track={tracks[virtualItem.index]!}
+									current={current === tracks[virtualItem.index]!.id}
+									onClick={onClick}
+									onSelect={onSelect}
+									draggable={orderable}
+									onAdd={setItemToAdd}
+									onNext={quickSwipeAction || addNextToPlaylist}
+									quickSwipeIcon={quickSwipeIcon}
+									quickSwipeDeleteAnim={quickSwipeDeleteAnim}
+									index={virtualItem.index}
+									selection={isSelection}
+									selected={isSelection && editViewState.selection.some(({ id }) => id === tracks[virtualItem.index]!.id)}
+								/>
+							</li>
+						))}
+					</div>
 				)}
-				{virtualizer && virtualizer((virtualItem) => (
-					<li
-						className={styles.item}
-						key={virtualItem.key}
-						data-index={virtualItem.index}
-					>
-						<TrackItem
-							track={tracks[virtualItem.index]!}
-							current={current === tracks[virtualItem.index]!.id}
-							onClick={onClick}
-							onSelect={onSelect}
-							draggable={orderable}
-							onAdd={setItemToAdd}
-							onNext={quickSwipeAction || addNextToPlaylist}
-							quickSwipeIcon={quickSwipeIcon}
-							quickSwipeDeleteAnim={quickSwipeDeleteAnim}
-							index={virtualItem.index}
-							selection={isSelection}
-							selected={isSelection && editViewState.selection.some(({ id }) => id === tracks[virtualItem.index]!.id)}
-						/>
-					</li>
-				))}
 				{!virtualizer && tracks.map((track, i) => (
 					<li
 						className={styles.item}

--- a/src/components/TrackList/useDragTrack.tsx
+++ b/src/components/TrackList/useDragTrack.tsx
@@ -126,9 +126,7 @@ export default function useDragTrack<T extends boolean> (
 				})
 			}, { signal, passive: true })
 
-			window.addEventListener("touchend", (event) => {
-				const match = getTouchFromId(event.changedTouches, touch.identifier)
-				if (!match) return
+			const onEnd = () => {
 				item.classList.remove(styles.drag)
 				item.style.removeProperty("--y")
 				item.style.removeProperty("--bg-y")
@@ -151,7 +149,19 @@ export default function useDragTrack<T extends boolean> (
 					const sibling = siblings.item(i) as HTMLElement
 					sibling.classList.remove(styles.slide)
 				}
+			}
+
+			window.addEventListener("touchend", (event) => {
+				const match = getTouchFromId(event.changedTouches, touch.identifier)
+				if (!match) return
+				onEnd()
 				callbacks.current!.onDrop!(itemIndex, itemIndex + itemsOffset)
+			}, { signal, passive: false })
+
+			window.addEventListener("touchcancel", (event) => {
+				const match = getTouchFromId(event.changedTouches, touch.identifier)
+				if (!match) return
+				onEnd()
 			}, { signal, passive: false })
 		}
 

--- a/src/components/TrackList/useDragTrack.tsx
+++ b/src/components/TrackList/useDragTrack.tsx
@@ -21,13 +21,12 @@ function iterateSiblings (
 	const firstIndex = Math.min(referenceIndex, extremumIndex)
 	const lastIndex = Math.max(referenceIndex, extremumIndex)
 	let sibling: HTMLElement | null = node.parentElement!.firstElementChild as HTMLElement
-	let index = Number(sibling.dataset.index)
 	do {
 		if (sibling !== node) {
+			const index = Number(sibling.dataset.index)
 			const isInRange = index >= firstIndex && index <= lastIndex
 			callback(sibling, isInRange)
 		}
-		index++
 	} while ((sibling = sibling.nextElementSibling as HTMLElement | null))
 }
 
@@ -72,7 +71,7 @@ export default function useDragTrack<T extends boolean> (
 				forceInsertVirtualDragItem.current = itemIndex
 			}
 
-			item.classList.add(styles.drag as string)
+			item.classList.add(styles.drag)
 
 			window.addEventListener("contextmenu", (event) => {
 				event.preventDefault()
@@ -99,9 +98,9 @@ export default function useDragTrack<T extends boolean> (
 					if (itemsOffset !== clampedItemsOffset) {
 						navigator.vibrate(1)
 						itemsOffset = clampedItemsOffset
-						iterateSiblings(item!, itemsOffset, (sibling, inRange) => {
-							sibling.classList.toggle(styles.slide as string, inRange)
-						})
+						iterateSiblings(item!, itemsOffset, (sibling, inRange) => (
+							sibling.classList.toggle(styles.slide, inRange)
+						))
 						item!.style.setProperty("--bg-y", `${itemsOffset}`)
 					}
 				})
@@ -130,7 +129,7 @@ export default function useDragTrack<T extends boolean> (
 			window.addEventListener("touchend", (event) => {
 				const match = getTouchFromId(event.changedTouches, touch.identifier)
 				if (!match) return
-				item.classList.remove(styles.drag as string)
+				item.classList.remove(styles.drag)
 				item.style.removeProperty("--y")
 				item.style.removeProperty("--bg-y")
 				controller.abort()
@@ -147,7 +146,11 @@ export default function useDragTrack<T extends boolean> (
 					cancelAnimationFrame(touchRafId)
 					touchRafId = null
 				}
-				Array.from(item.parentElement!.children).forEach((node) => node.classList.remove(styles.slide as string))
+				const siblings = item.parentElement!.children
+				for (let i = 0; i < siblings.length; i++) {
+					const sibling = siblings.item(i) as HTMLElement
+					sibling.classList.remove(styles.slide)
+				}
 				callbacks.current!.onDrop!(itemIndex, itemIndex + itemsOffset)
 			}, { signal, passive: false })
 		}

--- a/src/components/TrackList/useDragTrack.tsx
+++ b/src/components/TrackList/useDragTrack.tsx
@@ -1,8 +1,8 @@
-import { RefObject, useEffect } from "react"
+import { MutableRefObject, RefObject, useEffect } from "react"
 import getTouchFromId from "utils/getTouchFromId"
 import styles from "./index.module.css"
 
-function scrollParent(node: HTMLElement): HTMLElement {
+function scrollParent (node: HTMLElement): HTMLElement {
 	if (node.scrollHeight > node.clientHeight) {
 		return node
 	} else if (node.parentElement === document.documentElement) {
@@ -11,7 +11,7 @@ function scrollParent(node: HTMLElement): HTMLElement {
 	return scrollParent(node.parentElement!)
 }
 
-function iterateSiblings(
+function iterateSiblings (
 	node: HTMLElement,
 	offset: number,
 	callback: (node: HTMLElement, inRange: boolean) => void
@@ -20,43 +20,44 @@ function iterateSiblings(
 	const extremumIndex = referenceIndex + offset
 	const firstIndex = Math.min(referenceIndex, extremumIndex)
 	const lastIndex = Math.max(referenceIndex, extremumIndex)
-	function nextSibling(sibling: HTMLElement, index: number) {
+	let sibling: HTMLElement | null = node.parentElement!.firstElementChild as HTMLElement
+	let index = Number(sibling.dataset.index)
+	do {
 		if (sibling !== node) {
 			const isInRange = index >= firstIndex && index <= lastIndex
 			callback(sibling, isInRange)
 		}
-		if (sibling.nextElementSibling) {
-			nextSibling(sibling.nextElementSibling as HTMLElement, index + 1)
-		}
-	}
-	nextSibling(node.parentElement!.firstElementChild as HTMLElement, 0)
+		index++
+	} while ((sibling = sibling.nextElementSibling as HTMLElement | null))
 }
 
 export type Callbacks = {
 	onDrop: (from: number, to: number) => void
 }
 
-export default function useDragTrack<T extends boolean>(
+export default function useDragTrack<T extends boolean> (
 	ref: RefObject<HTMLElement>,
 	enabled: T,
-	callbacks: T extends true ? {current: Callbacks} : {current?: Partial<Callbacks>}
+	callbacks: T extends true ? { current: Callbacks } : { current?: Partial<Callbacks> },
+	count: number,
+	forceInsertVirtualDragItem?: MutableRefObject<number | null>,
 ) {
 	useEffect(() => {
 		if (!enabled) return
 		const element = ref.current
 		if (!element) return
 		const controller = new AbortController()
-		const {signal} = controller
+		const { signal } = controller
 
 		let isDragging = false
 		let uxController: AbortController | null = null
 		let scrollRafId: number | null = null
 		let touchRafId: number | null = null
 
-		function start(touch: Touch | null, item: HTMLElement | null) {
+		function start (touch: Touch | null, item: HTMLElement | null) {
 			if (!touch || !item) return
 			const controller = new AbortController()
-			const {signal} = controller
+			const { signal } = controller
 			uxController = controller
 			isDragging = true
 			let itemsOffset = 0
@@ -66,16 +67,18 @@ export default function useDragTrack<T extends boolean>(
 			const scrollContainer = scrollParent(item)
 			const initialScroll = scrollContainer.scrollTop
 			const itemHeight = item.offsetHeight
-			const totalSiblings = item.parentElement!.childElementCount
 			const itemIndex = Number(item.dataset.index)
+			if (forceInsertVirtualDragItem) {
+				forceInsertVirtualDragItem.current = itemIndex
+			}
 
 			item.classList.add(styles.drag as string)
 
 			window.addEventListener("contextmenu", (event) => {
 				event.preventDefault()
-			}, {signal})
+			}, { signal })
 
-			function scrollFrame(lastTime?: number) {
+			function scrollFrame (lastTime?: number) {
 				scrollRafId = requestAnimationFrame((time) => {
 					scrollFrame(time)
 
@@ -87,12 +90,12 @@ export default function useDragTrack<T extends boolean>(
 					// compute distance traveled
 					const totalOffset = dy + scrollContainer.scrollTop - initialScroll
 					item!.style.setProperty("--y", `${totalOffset}px`)
-					
+
 					// move siblings
 					const currentItemsOffset = totalOffset > 0
 						? Math.floor(totalOffset / itemHeight + 0.5)
 						: Math.ceil(totalOffset / itemHeight - 0.5)
-					const clampedItemsOffset = Math.min(totalSiblings - itemIndex - 1, Math.max(-itemIndex, currentItemsOffset))
+					const clampedItemsOffset = Math.min(count - itemIndex - 1, Math.max(-itemIndex, currentItemsOffset))
 					if (itemsOffset !== clampedItemsOffset) {
 						navigator.vibrate(1)
 						itemsOffset = clampedItemsOffset
@@ -122,7 +125,7 @@ export default function useDragTrack<T extends boolean>(
 							? (match.clientY - innerHeight * 3 / 4) / (innerHeight / 4)
 							: 0
 				})
-			}, {signal, passive: true})
+			}, { signal, passive: true })
 
 			window.addEventListener("touchend", (event) => {
 				const match = getTouchFromId(event.changedTouches, touch.identifier)
@@ -133,6 +136,9 @@ export default function useDragTrack<T extends boolean>(
 				controller.abort()
 				uxController = null
 				isDragging = false
+				if (forceInsertVirtualDragItem) {
+					forceInsertVirtualDragItem.current = null
+				}
 				if (scrollRafId) {
 					cancelAnimationFrame(scrollRafId)
 					scrollRafId = null
@@ -143,13 +149,13 @@ export default function useDragTrack<T extends boolean>(
 				}
 				Array.from(item.parentElement!.children).forEach((node) => node.classList.remove(styles.slide as string))
 				callbacks.current!.onDrop!(itemIndex, itemIndex + itemsOffset)
-			}, {signal, passive: false})
+			}, { signal, passive: false })
 		}
 
 		element.addEventListener("touchstart", (event) => {
 			const target = event.target as HTMLElement
 			if (!target.dataset.handle) return
-			
+
 			if (!isDragging) {
 				event.preventDefault()
 				event.stopPropagation()
@@ -158,14 +164,15 @@ export default function useDragTrack<T extends boolean>(
 				navigator.vibrate(1)
 				start(touch, item)
 			}
-		}, {signal, capture: true})
+		}, { signal, capture: true })
 
 		return () => {
 			controller.abort()
+			if (forceInsertVirtualDragItem) forceInsertVirtualDragItem.current = null
 			if (uxController) uxController.abort()
-			if(scrollRafId) cancelAnimationFrame(scrollRafId)
-			if(touchRafId) cancelAnimationFrame(touchRafId)
+			if (scrollRafId) cancelAnimationFrame(scrollRafId)
+			if (touchRafId) cancelAnimationFrame(touchRafId)
 		}
-	}, [ref, enabled, callbacks])
+	}, [ref, enabled, callbacks, count, forceInsertVirtualDragItem])
 
 }


### PR DESCRIPTION
TrackList exports a `useVirtualTracks` hook so that any parent can become a virtual list container for very long track lists.

We need to call react-virtual `useVirtualizer` in the parent for rendering order reasons. But really the entire logic is contained in TrackList and we're just passing props.

Because react-virtual causes many renders and `TrackItem` is a pretty heavy component, we `memo` it. Might need to look for better perf optimisations, but this seems to do the trick.

Because of `useDragTrack`, we need to override the range extractor. Currently we always render *every*  track between the one being dragged and the ones in the viewport. We could probably do better for performance with some maths, but this has seemed fine so far.

Because I wanted to only partially go through the virtualizer (only tracks, not other siblings like the cover), I have to overscan the # of items displayed (react-virtual doesn't calculate the size of the list correctly). There might be a better way than this... (as in more accurate / future-proof / flexible, but it works fine in terms of performance)

TODO
- [x] missing scroll-to-track when clicking on track name in player