### PR TITLE
Segmentation Fault error package downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.6",
-    "@prisma/client": "^4.13.0",
+    "@prisma/client": "^4.9.0",
     "@tanstack/react-query": "^4.29.3",
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "@trpc/client": "^10.21.1",
@@ -60,7 +60,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.39.0",
     "eslint-config-next": "13.3.1",
-    "prisma": "^4.13.0",
+    "prisma": "^4.9.0",
     "typescript": "5.0.4"
   }
 }


### PR DESCRIPTION
App has been throwing segfaults on start since upgrading major packages (next, trpc, prisma, next-auth). This PR aims at finding the guilty package and reverting to a stable version.

```sh
0|soft-serve-tunes  | 2023-04-23T10:34:06: Segmentation fault (core dumped)
PM2                 | App [soft-serve-tunes:0] exited with code [139] via signal [SIGINT]
PM2                 | App [soft-serve-tunes:0] starting in -fork mode-
PM2                 | App [soft-serve-tunes:0] online
```

Apparently it might be coming from Prisma (https://github.com/prisma/prisma/issues/18510). So I'm trying versions between 4.9 (never seen the issue), and 4.13 (first time seeing the issue, never tried versions in between).

---

prisma version (taken after a bunch of re-installs, at a time where I don't reproduce the segfault anymore...). But still, it was on 4.13 that I got the error, and that was at a 1-hour interval max on a sunday so hopefully it's the same exact version.
```sh
prisma                  : 4.13.0
@prisma/client          : 4.13.0
Current platform        : linux-arm64-openssl-1.1.x
Query Engine (Node-API) : libquery-engine 1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a (at node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-1.1.x.so.node)
Migration Engine        : migration-engine-cli 1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a (at node_modules/@prisma/engines/migration-engine-linux-arm64-openssl-1.1.x)
Format Wasm             : @prisma/prisma-fmt-wasm 4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a
Default Engines Hash    : 1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a
Studio                  : 0.484.0
Preview Features        : extendedWhereUnique
```

```sh
$ node -v
v18.12.1

$ uname -a
Linux raspberrypi 5.15.61-v8+ #1579 SMP PREEMPT Fri Aug 26 11:16:44 BST 2022 aarch64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye

$ openssl version
OpenSSL 1.1.1n  15 Mar 2022

$ psql -V
psql (PostgreSQL) 13.8 (Debian 13.8-0+deb11u1)
```

```sql
# SELECT version();
                                                             version                                                             
---------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 13.8 (Debian 13.8-0+deb11u1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
(1 row)
```